### PR TITLE
CB-18-tools-color

### DIFF
--- a/frontend/src/components/LandingPage/Tools/Tools.css
+++ b/frontend/src/components/LandingPage/Tools/Tools.css
@@ -1,7 +1,31 @@
+/**
+ *  Center and color all text on page.----------------------------------
+ */
 #tools-title {
     text-align: center;
+    color: #2d4d46;
 }
 
+p {
+    color: #2d4d46;
+}
+
+/**
+ *  Make the images color on mouse hover.-------------------------------
+ */
+ img {
+    -webkit-filter: grayscale(100%); /* Safari 6.0 - 9.0 */
+    filter: grayscale(100%);
+}
+
+img:hover {
+    -webkit-filter: grayscale(0);
+    filter: grayscale(0);
+}
+
+/**
+ *  Image centering and spacing all images properly.--------------------
+ */
 #main-logos {
     display: flex;
     align-items: center;
@@ -28,6 +52,9 @@
     justify-content: center;
 }
 
+/**
+ *  Responsive adjustment for images
+ */
 @media (max-width: 576px) {
     #main-logos {
         max-width: 300px;

--- a/frontend/src/components/LandingPage/Tools/Tools.css
+++ b/frontend/src/components/LandingPage/Tools/Tools.css
@@ -1,4 +1,12 @@
 /**
+ *  Change the jumbotron backgrou color
+ */ 
+.jumbotron {
+    background: linear-gradient(25deg, #e3c3b2 25%, rgba(0, 0, 0, 0) 25%), 
+                linear-gradient(70deg, #f1eee9 90%, #e3c3b2 90%) !important;
+}
+
+/**
  *  Center and color all text on page.----------------------------------
  */
 #tools-title {

--- a/frontend/src/components/LandingPage/Tools/Tools.css
+++ b/frontend/src/components/LandingPage/Tools/Tools.css
@@ -6,19 +6,19 @@
     color: #2d4d46;
 }
 
-p {
+p.lead {
     color: #2d4d46;
 }
 
 /**
  *  Make the images color on mouse hover.-------------------------------
  */
- img {
-    -webkit-filter: grayscale(100%); /* Safari 6.0 - 9.0 */
+ #main-logos img, #api-logos img {
+    -webkit-filter: grayscale(100%);
     filter: grayscale(100%);
 }
 
-img:hover {
+#main-logos img:hover , #api-logos img:hover {
     -webkit-filter: grayscale(0);
     filter: grayscale(0);
 }
@@ -26,10 +26,10 @@ img:hover {
 /**
  *  Image centering and spacing all images properly.--------------------
  */
-#main-logos {
+#main-logos, #api-logos{
     display: flex;
     align-items: center;
-    justify-content: center;
+    justify-content: center;    
 }
 
 #nodejs-logo {
@@ -44,12 +44,6 @@ img:hover {
 
 #heroku-logo {
     margin-left: 1vw;
-}
-
-#api-logos {
-    display: flex;
-    align-items: center;
-    justify-content: center;
 }
 
 /**

--- a/frontend/src/components/LandingPage/Tools/Tools.css
+++ b/frontend/src/components/LandingPage/Tools/Tools.css
@@ -13,7 +13,7 @@ p.lead {
 /**
  *  Make the images color on mouse hover.-------------------------------
  */
- #main-logos img, #api-logos img {
+#main-logos img, #api-logos img {
     -webkit-filter: grayscale(100%);
     filter: grayscale(100%);
 }

--- a/frontend/src/components/LandingPage/Tools/Tools.js
+++ b/frontend/src/components/LandingPage/Tools/Tools.js
@@ -7,7 +7,8 @@ import {
   function Tools() {
     return (
       <div>
-        <Jumbotron fluid style={{ background: 'linear-gradient(25deg, #e3c3b2 25%, rgba(0, 0, 0, 0) 25%), linear-gradient(70deg, #f1eee9 90%, #e3c3b2 90%)' }}>
+        <Jumbotron fluid style={{ background: `linear-gradient(25deg, #e3c3b2 25%, rgba(0, 0, 0, 0) 25%), 
+                                               linear-gradient(70deg, #f1eee9 90%, #e3c3b2 90%)` }}>
           <Container fluid>
             <h1 id='tools-title' className='display-4'>Built Using</h1>
             <hr className='my-4' width='250' />

--- a/frontend/src/components/LandingPage/Tools/Tools.js
+++ b/frontend/src/components/LandingPage/Tools/Tools.js
@@ -7,8 +7,7 @@ import {
   function Tools() {
     return (
       <div>
-        <Jumbotron fluid style={{ background: `linear-gradient(25deg, #e3c3b2 25%, rgba(0, 0, 0, 0) 25%), 
-                                               linear-gradient(70deg, #f1eee9 90%, #e3c3b2 90%)` }}>
+        <Jumbotron fluid>
           <Container fluid>
             <h1 id='tools-title' className='display-4'>Built Using</h1>
             <hr className='my-4' width='250' />

--- a/frontend/src/components/LandingPage/Tools/Tools.js
+++ b/frontend/src/components/LandingPage/Tools/Tools.js
@@ -7,7 +7,7 @@ import {
   function Tools() {
     return (
       <div>
-        <Jumbotron fluid style={{ background: 'linear-gradient(110deg, #2d4d46 10%, rgba(0, 0, 0, 0) 10%), linear-gradient(55deg, #dfd5d1 20%, #f1eee9 20% 95%, #e3c3b2 95%)' }}>
+        <Jumbotron fluid style={{ background: 'linear-gradient(25deg, #e3c3b2 25%, rgba(0, 0, 0, 0) 25%), linear-gradient(70deg, #f1eee9 90%, #e3c3b2 90%)' }}>
           <Container fluid>
             <h1 id='tools-title' className='display-4'>Built Using</h1>
             <hr className='my-4' width='250' />

--- a/frontend/src/components/LandingPage/Tools/Tools.js
+++ b/frontend/src/components/LandingPage/Tools/Tools.js
@@ -7,7 +7,7 @@ import {
   function Tools() {
     return (
       <div>
-        <Jumbotron fluid>
+        <Jumbotron fluid style={{ background: 'linear-gradient(110deg, #2d4d46 10%, rgba(0, 0, 0, 0) 10%), linear-gradient(55deg, #dfd5d1 20%, #f1eee9 20% 95%, #e3c3b2 95%)' }}>
           <Container fluid>
             <h1 id='tools-title' className='display-4'>Built Using</h1>
             <hr className='my-4' width='250' />


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The pull request title contains the ticket number in the title. For example [CB-1]


* **What kind of change does this PR introduce?** (Bug fix, new feature...)
The tools component background and text was changed to be consistent with the new color scheme that was chosen. The logo images were also changed to be grayscale to reduce the color clashing. The images will now only show up as color images when the user's mouse hovers over the image.


* **What is the current behavior? What does the code do before you made the new changes?** 
The current behavior was that the tools component was a default configuration of the reactstrap jumbotron. The layout of the jumbotron was the same.


* **What is the new behavior?**
The behavior is that the color scheme has changed for the jumbotron background, text color, and image colors.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR? Run a new command?)
No; there is no breaking change.


* **Other information**:
![image](https://user-images.githubusercontent.com/51031158/99615354-e406dc00-29e0-11eb-98f6-b418b7ac8582.png)
